### PR TITLE
WDP190401-9

### DIFF
--- a/src/sass/_placeholders.scss
+++ b/src/sass/_placeholders.scss
@@ -1,0 +1,3 @@
+%animated-element {
+  transition: background 0.25s, color 0.25s;
+}

--- a/src/sass/components/_button.scss
+++ b/src/sass/components/_button.scss
@@ -1,4 +1,5 @@
 .btn-main {
+  @extend %animated-element;
   background-color: #2a2a2a;
   color: #ffffff;
   font-size: 16px;
@@ -22,6 +23,7 @@
 }
 
 .btn-outline {
+  @extend %animated-element;
   display: inline-block;
   padding: 5px 10px;
   border: 1px solid #2a2a2a;

--- a/src/sass/components/_footer.scss
+++ b/src/sass/components/_footer.scss
@@ -16,6 +16,7 @@ footer {
         list-style: none;
         li {
           a {
+            @extend %animated-element;
             font-size: 14px;
             line-height: 30px;
             color: rgb(169, 169, 169);
@@ -66,6 +67,7 @@ footer {
           margin-left: 1rem;
 
           a {
+            @extend %animated-element;
             color: rgb(169, 169, 169);
             text-decoration: none;
 

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -12,6 +12,7 @@ header {
         line-height: 55px;
 
         a {
+          @extend %animated-element;
           color: #ffffff;
           font-size: 13px;
 
@@ -72,6 +73,7 @@ header {
         color: #ffffff;
 
         .cart-icon {
+          @extend %animated-element;
           background-color: $primary;
           width: 55px;
           height: 50px;
@@ -134,6 +136,7 @@ header {
           align-items: stretch;
 
           a {
+            @extend %animated-element;
             color: $text-color;
             text-transform: uppercase;
             font-size: 12px;

--- a/src/sass/components/_panel-bar.scss
+++ b/src/sass/components/_panel-bar.scss
@@ -74,6 +74,7 @@
         margin-left: 0.5rem;
 
         a {
+          @extend %animated-element;
           display: block;
           width: 13px;
           height: 13px;

--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -1,4 +1,5 @@
 @import "variables";
+@import "placeholders";
 
 @import url("https://fonts.googleapis.com/css?family=Poppins:100,200,300,400,500,600,700,800,900");
 


### PR DESCRIPTION
Należało nadać jednakowy efekt animacji dla wszystkich elementów, dla których w stanie hover zmienia się kolor tła i/lub tekstu. Aby klient mógł łatwo zmieniać czas animacji, należało to zrobić za pomocą extendowania placeholdera.

**Rozwiązanie:**
Aby placeholder działał globalnie, utworzyłam w katalogu sass nowy plik `_placeholders.scss` i zaimportowałam go do `style.scss`. Placeholderowi `%animated-element` nadałam wstępnie `transition: background 0.25s, color 0.25s;`. Dodałam `@extend %animated-element;` do wszystkich elementów, które aktualnie mają efekt hover.

**Uwaga:**
Trzeba będzie powtórzyć tę czynność dla wszystkich elementów, które aktualnie nie są jeszcze na masterze, a które również będę potrzebowały efektu animacji, jak np. select, czy karty postów. 
