### PR TITLE
WDP190401-16

### DIFF
--- a/src/partials/90_footer.html
+++ b/src/partials/90_footer.html
@@ -2,7 +2,7 @@
   <div class="footer-menu">
     <div class="container">
       <div class="row">
-        <div class="col">
+        <div class="col-12 col-sm-6 col-lg-3">
           <div class="menu-wrapper">
             <h6>Information</h6>
             <ul>
@@ -13,7 +13,7 @@
             </ul>
           </div>
         </div>
-        <div class="col">
+        <div class="col-12 col-sm-6 col-lg-3">
           <div class="menu-wrapper">
             <h6>My account</h6>
             <ul>
@@ -24,7 +24,7 @@
             </ul>
           </div>
         </div>
-        <div class="col">
+        <div class="col-12 col-sm-6 col-lg-3">
           <div class="menu-wrapper">
             <h6>Information</h6>
             <ul>
@@ -35,7 +35,7 @@
             </ul>
           </div>
         </div>
-        <div class="col">
+        <div class="col-12 col-sm-6 col-lg-3">
           <div class="menu-wrapper">
             <h6>Orders</h6>
             <ul>
@@ -53,11 +53,11 @@
   <div class="bottom-bar">
     <div class="container">
       <div class="row align-items-center">
-        <div class="col"></div>
-        <div class="col copyright text-center">
+        <div class="col-12 col-sm-12 col-lg-12"></div>
+        <div class="col-6 col-sm-6 col-lg-6 copyright text-left">
           <p>©Copyright 2016 Bazar | All Rights Reserved</p>
         </div>
-        <div class="col socialmedia text-right">
+        <div class="col-6 col-sm-6 col-lg-6 socialmedia text-right">
           <ul>
             <li>
               <a href="#"><i class="fab fa-twitter"></i></a>

--- a/src/partials/90_footer.html
+++ b/src/partials/90_footer.html
@@ -53,7 +53,7 @@
   <div class="bottom-bar">
     <div class="container">
       <div class="row align-items-center">
-        <div class="col-12 col-sm-12 col-lg-12"></div>
+        <div class="col-12 col-sm-12 col-lg-12 empty-space"></div>
         <div class="col-6 col-sm-6 col-lg-6 copyright text-left">
           <p>©Copyright 2016 Bazar | All Rights Reserved</p>
         </div>

--- a/src/sass/components/_footer.scss
+++ b/src/sass/components/_footer.scss
@@ -2,7 +2,9 @@ footer {
   .footer-menu {
     background-color: $footer-bg;
     padding: 3rem 0;
-
+    .col-12 {
+      text-align: center;
+    }
     .menu-wrapper {
       h6 {
         color: #ffffff;
@@ -52,10 +54,12 @@ footer {
         color: rgb(169, 169, 169);
         font-size: 14px;
         line-height: 26px;
+        text-align: left;
       }
     }
 
     .socialmedia {
+      text-align: right;
       ul {
         margin: 0;
         padding: 0;

--- a/src/sass/components/_footer.scss
+++ b/src/sass/components/_footer.scss
@@ -57,7 +57,9 @@ footer {
         text-align: left;
       }
     }
-
+    .empty-space {
+      text-align: center;
+    }
     .socialmedia {
       text-align: right;
       ul {


### PR DESCRIPTION
Górna partia stopki ma 2 elementy na ekranach mniejszych niż 992px i 1 element na ekranach mniejszych niż 576px. 
W dolnej partii stopki copyright umieściłem po lewej stronie, a socjalki po prawej dla wszystkich rozmiarów ekranu. Miejsce po lewej, w którym na razie nic nie ma, zajmuje cała szerokość ekranu, zostało wypośrodkowane i znajduje się nad copyright i socjalkami. 